### PR TITLE
Skip username regex validation for JIT provisioning

### DIFF
--- a/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UserStoreActionListener.java
+++ b/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UserStoreActionListener.java
@@ -72,7 +72,7 @@ public class UserStoreActionListener extends AbstractIdentityUserOperationEventL
         }
 
         ValidationResult usernameValidationResult = isUsernameValid(userName, userStoreManager.getRealmConfiguration());
-        if (!usernameValidationResult.isValid()) {
+        if (!usernameValidationResult.isValid() && !UserCoreUtil.getSkipUsernamePatternValidationThreadLocal()) {
             String errorCode = ERROR_CODE_INVALID_USER_NAME.getCode();
             String errorMessage = String
                     .format(ERROR_CODE_INVALID_USER_NAME.getMessage(), UserCoreUtil.removeDomainFromName(userName),


### PR DESCRIPTION
### Proposed changes in this pull request

Unique identifier is returned as subject identifier for a federated user during JIT provisioning. Therefore this PR skip the username regex validation during JIT provisioning flow.


### When should this PR be merged
Need to merge after merging the relevant kernal PR https://github.com/wso2/carbon-kernel/pull/3263
