### PR TITLE
 Skip username regex validation for JIT provisioning

### DIFF
--- a/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UserStoreActionListener.java
+++ b/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UserStoreActionListener.java
@@ -81,7 +81,7 @@ public class UserStoreActionListener extends AbstractIdentityUserOperationEventL
         }
 
         ValidationResult usernameValidationResult = isUsernameValid(userName, userStoreManager.getRealmConfiguration());
-        if (!usernameValidationResult.isValid()) {
+        if (!usernameValidationResult.isValid()  && !UserCoreUtil.getSkipUsernamePatternValidationThreadLocal()) {
             String errorCode = ERROR_CODE_INVALID_USER_NAME.getCode();
             String errorMessage = String
                     .format(ERROR_CODE_INVALID_USER_NAME.getMessage(), UserCoreUtil.removeDomainFromName(userName),

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
 
     <properties>
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.6.2-m9</carbon.kernel.version>
+        <carbon.kernel.version>4.7.0-beta</carbon.kernel.version>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request

Unique identifier is returned as subject identifier for a federated user during JIT provisioning. Therefore this PR skip the username regex validation during JIT provisioning flow.


### When should this PR be merged
Need to merge after merging the relevant kernal PR https://github.com/wso2/carbon-kernel/pull/3263
