### PR TITLE
Skip workflow for user & role sharing

### DIFF
--- a/components/org.wso2.carbon.user.mgt.workflow/pom.xml
+++ b/components/org.wso2.carbon.user.mgt.workflow/pom.xml
@@ -63,6 +63,10 @@
             <artifactId>org.wso2.carbon.identity.role.v2.mgt.core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.organization.user.sharing</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
@@ -115,7 +119,9 @@
                             org.wso2.carbon.identity.recovery.util; version="${identity.governance.package.import.version.range}",
                             org.wso2.carbon.identity.event.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.password.policy.*;version="${identity.governance.package.import.version.range}",
-                            org.wso2.carbon.identity.input.validation.mgt.utils; version="${carbon.identity.package.import.version.range}"
+                            org.wso2.carbon.identity.input.validation.mgt.utils; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.organization.management.organization.user.sharing;
+                            version="${org.wso2.identity.organization.mgt.import.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.user.mgt.workflow.internal;version="${identity.user.workflow.exp.pkg.version}",

--- a/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UserStoreActionListener.java
+++ b/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UserStoreActionListener.java
@@ -51,6 +51,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.CLAIM_MANAGED_ORGANIZATION;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_INVALID_PASSWORD;
 import static org.wso2.carbon.user.core.constants.UserCoreErrorConstants.ErrorMessages.ERROR_CODE_INVALID_USER_NAME;
 import static org.wso2.carbon.user.mgt.workflow.util.UserStoreWFUtils.isPasswordValid;
@@ -102,6 +103,10 @@ public class UserStoreActionListener extends AbstractIdentityUserOperationEventL
             return true;
         }
 
+        if (claims != null && claims.containsKey(CLAIM_MANAGED_ORGANIZATION)) {
+            // User add workflow is not supported for the shared users.
+            return true;
+        }
         validateUserName(userName, credential, roleList, claims, profile, userStoreManager);
         validatePassword(credential, userName, roleList, claims, profile, userStoreManager);
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
                 <version>${identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.organization.user.sharing</artifactId>
+                <version>${org.wso2.identity.organization.mgt.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.governance</groupId>
                 <artifactId>org.wso2.carbon.identity.recovery</artifactId>
                 <version>${identity.governance.version}</version>
@@ -342,6 +347,9 @@
         <identity.user.workflow.exp.pkg.version>${project.version}</identity.user.workflow.exp.pkg.version>
         <identity.governance.version>1.4.1</identity.governance.version>
         <identity.governance.package.import.version.range>[1.4.1, 2)</identity.governance.package.import.version.range>
+        <org.wso2.identity.organization.mgt.version>2.0.3</org.wso2.identity.organization.mgt.version>
+        <org.wso2.identity.organization.mgt.import.version.range>[1.0.0,3.0.0)
+        </org.wso2.identity.organization.mgt.import.version.range>
 
         <!--Carbon component version-->
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request

The workflow support for the user creation and role creation is provided. But user sharing and role sharing is a different process which includes parts of the workflow support operations.

We should bring the workflow support for such operations explicitly if required. Hence exclude them in the user & role creation handlers.

### Related Issues
- https://github.com/wso2/product-is/issues/23374