### PR TITLE
Fix role user assignment approval requests with deleted users

### DIFF
--- a/components/org.wso2.carbon.user.mgt.workflow/pom.xml
+++ b/components/org.wso2.carbon.user.mgt.workflow/pom.xml
@@ -94,7 +94,7 @@
                         <Import-Package>
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
-                            org.apache.commons.collections,
+                            org.apache.commons.collections; version="${commons-collections.wso2.osgi.version.range}",
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
                             org.wso2.carbon.identity.workflow.mgt.exception; version="${carbon.identity.package.import.version.range}",

--- a/components/org.wso2.carbon.user.mgt.workflow/pom.xml
+++ b/components/org.wso2.carbon.user.mgt.workflow/pom.xml
@@ -94,6 +94,7 @@
                         <Import-Package>
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
+                            org.apache.commons.collections,
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
                             org.wso2.carbon.identity.workflow.mgt.exception; version="${carbon.identity.package.import.version.range}",

--- a/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UpdateRoleV2UsersWFRequestHandler.java
+++ b/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UpdateRoleV2UsersWFRequestHandler.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.carbon.user.mgt.workflow.userstore;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.CarbonContext;
@@ -167,7 +168,8 @@ public class UpdateRoleV2UsersWFRequestHandler extends AbstractWorkflowRequestHa
             RoleManagementService roleManagementService = IdentityWorkflowDataHolder.getInstance()
                     .getRoleManagementService();
             try {
-                roleManagementService.updateUserListOfRole(roleId, newUsers, deletedUsers, tenantDomain);
+                roleManagementService.updateUserListOfRole(roleId, filterExistingUserIds(newUsers),
+                        filterExistingUserIds(deletedUsers), tenantDomain);
             } catch (IdentityRoleManagementException e) {
                 throw new WorkflowException(e.getMessage(), e);
             }
@@ -235,5 +237,35 @@ public class UpdateRoleV2UsersWFRequestHandler extends AbstractWorkflowRequestHa
             }
         }
         return true;
+    }
+
+    /**
+     * Filters the list of user IDs to only include those that exist in the user store.
+     *
+     * @param userIds List of user IDs to filter.
+     * @return List of valid user IDs that exist in the user store.
+     * @throws WorkflowException if an error occurs while checking user existence.
+     */
+    private List<String> filterExistingUserIds(List<String> userIds) throws WorkflowException {
+
+        List<String> validUserIds = new ArrayList<>();
+        if (CollectionUtils.isEmpty(userIds)) {
+            return validUserIds;
+        }
+        AbstractUserStoreManager userStoreManager = UserStoreWFUtils.getUserStoreManager();
+        for (String userId : userIds) {
+            try {
+                if (userStoreManager.isExistingUserWithID(userId)) {
+                    validUserIds.add(userId);
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.warn("User with ID: " + userId + " does not exist.");
+                    }
+                }
+            } catch (org.wso2.carbon.user.core.UserStoreException e) {
+                throw new WorkflowException(e.getMessage(), e);
+            }
+        }
+        return validUserIds;
     }
 }

--- a/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UpdateRoleV2UsersWFRequestHandler.java
+++ b/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UpdateRoleV2UsersWFRequestHandler.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.user.mgt.workflow.userstore;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.CarbonContext;
@@ -255,12 +256,13 @@ public class UpdateRoleV2UsersWFRequestHandler extends AbstractWorkflowRequestHa
         AbstractUserStoreManager userStoreManager = UserStoreWFUtils.getUserStoreManager();
         for (String userId : userIds) {
             try {
+                if (StringUtils.isBlank(userId)) {
+                    continue;
+                }
                 if (userStoreManager.isExistingUserWithID(userId)) {
                     validUserIds.add(userId);
                 } else {
-                    if (log.isDebugEnabled()) {
-                        log.warn("User with ID: " + userId + " does not exist.");
-                    }
+                    log.debug("User with ID: " + userId + " does not exist.");
                 }
             } catch (org.wso2.carbon.user.core.UserStoreException e) {
                 throw new WorkflowException(e.getMessage(), e);

--- a/pom.xml
+++ b/pom.xml
@@ -339,6 +339,7 @@
         <commons-io.wso2.version>2.4.0.wso2v1</commons-io.wso2.version>
         <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
+        <commons-collections.wso2.osgi.version.range>[3.2.0, 4.0.0)</commons-collections.wso2.osgi.version.range>
         <commons-cli.osgi.version>1.2.0.wso2v1</commons-cli.osgi.version>
 
         <!--Carbon identity version-->


### PR DESCRIPTION
### Proposed changes in this pull request

Issue: Approval requests containing deleted user IDs cause role assignment to fail for all users, including valid ones.
Fix: Added a user existence check before updating role memberships to ensure valid users are processed successfully, even if some user IDs are no longer present.

**User ID validation for role updates:**

* Added a new private method `filterExistingUserIds` to `UpdateRoleV2UsersWFRequestHandler.java`, which checks each user ID against the user store and returns only those that exist. This helps prevent errors caused by non-existent users during role updates.
* Updated the call to `roleManagementService.updateUserListOfRole` to use the filtered lists of user IDs for both additions and deletions, ensuring only valid users are affected by role changes.

**Dependency management:**

* Imported `org.apache.commons.collections.CollectionUtils` in `UpdateRoleV2UsersWFRequestHandler.java` to simplify empty collection checks.
* Added `org.apache.commons.collections` to the `Import-Package` section in `pom.xml` to support the new dependency.

### Related Issues
- https://github.com/wso2/product-is/issues/25320

### Related PRs
- https://github.com/wso2/identity-apps/pull/8872
