### PR TITLE
Skip agent userstore in add and delete user workflows

### DIFF
--- a/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/RoleManagementActionListener.java
+++ b/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/RoleManagementActionListener.java
@@ -104,12 +104,8 @@ public class RoleManagementActionListener extends AbstractRoleManagementListener
         if (!isEnable() || !isEventAssociatedWithWorkflow(UserStoreWFConstants.UPDATE_ROLE_V2_USERS_EVENT)) {
             return;
         }
-
-        List<String> filteredNewUserIDList = filterAgents(newUserIDList);
-        List<String> filteredDeletedUserIDList = filterAgents(deletedUserIDList);
-
         // If both new and deleted user lists are empty after filtering, return.
-        if (CollectionUtils.isEmpty(filteredNewUserIDList) && CollectionUtils.isEmpty(filteredDeletedUserIDList)) {
+        if (containsOnlyAgentUsers(newUserIDList, deletedUserIDList)) {
             return;
         }
         UpdateRoleV2UsersWFRequestHandler addRoleWFRequestHandler = new UpdateRoleV2UsersWFRequestHandler();
@@ -139,6 +135,21 @@ public class RoleManagementActionListener extends AbstractRoleManagementListener
         String requestInitiatedOrganization = IdentityTenantUtil.getTenantDomainFromContext();
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         return !StringUtils.equals(requestInitiatedOrganization, tenantDomain);
+    }
+
+    /**
+     * Checks whether the provided user ID lists contain only agent users.
+     *
+     * @param newUserIDList     List of new user IDs to be added to the role.
+     * @param deletedUserIDList List of user IDs to be removed from the role.
+     * @return true if both lists contain only agent users, false otherwise.
+     * @throws IdentityRoleManagementException if an error occurs while checking user existence.
+     */
+    private boolean containsOnlyAgentUsers(List<String> newUserIDList, List<String> deletedUserIDList)
+            throws IdentityRoleManagementException {
+
+        return CollectionUtils.isEmpty(filterAgents(newUserIDList)) &&
+                CollectionUtils.isEmpty(filterAgents(deletedUserIDList));
     }
 
     /**
@@ -181,6 +192,7 @@ public class RoleManagementActionListener extends AbstractRoleManagementListener
      * @throws IdentityRoleManagementException if error while retrieving user realm
      */
     private AbstractUserStoreManager getUserStoreManager() throws IdentityRoleManagementException {
+
         RealmService realmService = IdentityWorkflowDataHolder.getInstance().getRealmService();
         UserRealm userRealm;
         AbstractUserStoreManager userStoreManager;

--- a/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UpdateRoleV2UsersWFRequestHandler.java
+++ b/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UpdateRoleV2UsersWFRequestHandler.java
@@ -23,7 +23,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
 import org.wso2.carbon.identity.workflow.mgt.WorkflowManagementService;
@@ -261,33 +260,6 @@ public class UpdateRoleV2UsersWFRequestHandler extends AbstractWorkflowRequestHa
                     continue;
                 }
                 if (userStoreManager.isExistingUserWithID(userId)) {
-                    validUserIds.add(userId);
-                } else {
-                    log.debug("User with ID: " + userId + " does not exist.");
-                }
-            } catch (org.wso2.carbon.user.core.UserStoreException e) {
-                throw new WorkflowException(e.getMessage(), e);
-            }
-        }
-        return validUserIds;
-    }
-
-    private List<String> filterAgents(List<String> userIds) throws WorkflowException {
-
-        List<String> validUserIds = new ArrayList<>();
-        if (CollectionUtils.isEmpty(userIds)) {
-            return validUserIds;
-        }
-        AbstractUserStoreManager userStoreManager = UserStoreWFUtils.getUserStoreManager();
-        for (String userId : userIds) {
-            try {
-                if (StringUtils.isBlank(userId)) {
-                    continue;
-                }
-                String username = userStoreManager.getUserNameFromUserID(userId);
-                String domain = IdentityUtil.extractDomainFromName(username);
-                if (userStoreManager.isExistingUserWithID(userId) &&
-                        !IdentityUtil.getAgentIdentityUserstoreName().equals(domain)) {
                     validUserIds.add(userId);
                 } else {
                     log.debug("User with ID: " + userId + " does not exist.");

--- a/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UserStoreActionListener.java
+++ b/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UserStoreActionListener.java
@@ -100,7 +100,8 @@ public class UserStoreActionListener extends AbstractIdentityUserOperationEventL
                                 String profile, UserStoreManager userStoreManager) throws UserStoreException {
 
         if (!isEnable() || isCalledViaIdentityMgtListners()
-                || !isEventAssociatedWithWorkflow(UserStoreWFConstants.ADD_USER_EVENT) || isJITProvisioningFlow()) {
+                || !isEventAssociatedWithWorkflow(UserStoreWFConstants.ADD_USER_EVENT) || isJITProvisioningFlow()
+                || isAgentUserStore(userStoreManager)) {
             return true;
         }
 
@@ -152,7 +153,8 @@ public class UserStoreActionListener extends AbstractIdentityUserOperationEventL
     public boolean doPreDeleteUser(String userName, UserStoreManager userStoreManager) throws UserStoreException {
 
         if (!isEnable() || isCalledViaIdentityMgtListners()
-                || !isEventAssociatedWithWorkflow(UserStoreWFConstants.DELETE_USER_EVENT)) {
+                || !isEventAssociatedWithWorkflow(UserStoreWFConstants.DELETE_USER_EVENT)
+                || isAgentUserStore(userStoreManager)) {
             return true;
         }
         try {
@@ -545,5 +547,21 @@ public class UserStoreActionListener extends AbstractIdentityUserOperationEventL
     private boolean isDisabled() {
 
         return true;
+    }
+
+    /**
+     * Check if the user store is the agent user store.
+     *
+     * @param userStoreManager user store manager
+     * @return true if the user store is the agent user store
+     */
+    private boolean isAgentUserStore(UserStoreManager userStoreManager) {
+
+        String domain = userStoreManager.getRealmConfiguration()
+                .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+        if (IdentityUtil.getAgentIdentityUserstoreName().equals(domain)) {
+            return true;
+        }
+        return false;
     }
 }

--- a/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UserStoreActionListener.java
+++ b/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UserStoreActionListener.java
@@ -44,6 +44,7 @@ import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.user.mgt.workflow.internal.IdentityWorkflowDataHolder;
 import org.wso2.carbon.user.mgt.workflow.util.UserStoreWFConstants;
+import org.wso2.carbon.user.mgt.workflow.util.UserStoreWFUtils;
 import org.wso2.carbon.user.mgt.workflow.util.ValidationResult;
 
 import java.util.Arrays;
@@ -101,7 +102,7 @@ public class UserStoreActionListener extends AbstractIdentityUserOperationEventL
 
         if (!isEnable() || isCalledViaIdentityMgtListners()
                 || !isEventAssociatedWithWorkflow(UserStoreWFConstants.ADD_USER_EVENT) || isJITProvisioningFlow()
-                || isAgentUserStore(userStoreManager)) {
+                || UserStoreWFUtils.isAgentUserStore(userStoreManager)) {
             return true;
         }
 
@@ -154,7 +155,7 @@ public class UserStoreActionListener extends AbstractIdentityUserOperationEventL
 
         if (!isEnable() || isCalledViaIdentityMgtListners()
                 || !isEventAssociatedWithWorkflow(UserStoreWFConstants.DELETE_USER_EVENT)
-                || isAgentUserStore(userStoreManager)) {
+                || UserStoreWFUtils.isAgentUserStore(userStoreManager)) {
             return true;
         }
         try {
@@ -547,21 +548,5 @@ public class UserStoreActionListener extends AbstractIdentityUserOperationEventL
     private boolean isDisabled() {
 
         return true;
-    }
-
-    /**
-     * Check if the user store is the agent user store.
-     *
-     * @param userStoreManager user store manager
-     * @return true if the user store is the agent user store
-     */
-    private boolean isAgentUserStore(UserStoreManager userStoreManager) {
-
-        String domain = userStoreManager.getRealmConfiguration()
-                .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
-        if (IdentityUtil.getAgentIdentityUserstoreName().equals(domain)) {
-            return true;
-        }
-        return false;
     }
 }

--- a/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/util/UserStoreWFUtils.java
+++ b/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/util/UserStoreWFUtils.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.recovery.model.Property;
 import org.wso2.carbon.identity.recovery.util.Utils;
 import org.wso2.carbon.identity.workflow.mgt.exception.WorkflowException;
@@ -253,5 +254,18 @@ public class UserStoreWFUtils {
             throw new WorkflowException("Error while retrieving user realm.", e);
         }
         return userStoreManager;
+    }
+
+    /**
+     * Check if the user store is the agent user store.
+     *
+     * @param userStoreManager user store manager
+     * @return true if the user store is the agent user store
+     */
+    public static boolean isAgentUserStore(UserStoreManager userStoreManager) {
+
+        String domain = userStoreManager.getRealmConfiguration()
+                .getUserStoreProperty(UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME);
+        return IdentityUtil.getAgentIdentityUserstoreName().equals(domain);
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

$subject

> Note : This fix only skips the agent in a role update when all the user IDs passed for the role update are agents.

### Related Issues
- https://github.com/wso2/product-is/issues/25495
