### PR TITLE
Add workflow support for updating claims of users

### DIFF
--- a/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UserStoreActionListener.java
+++ b/components/org.wso2.carbon.user.mgt.workflow/src/main/java/org/wso2/carbon/user/mgt/workflow/userstore/UserStoreActionListener.java
@@ -223,7 +223,8 @@ public class UserStoreActionListener extends AbstractIdentityUserOperationEventL
     public boolean doPreSetUserClaimValues(String userName, Map<String, String> claims, String profileName,
                                            UserStoreManager userStoreManager) throws UserStoreException {
 
-        if (!isEnable() || isCalledViaIdentityMgtListners() || isDisabled()) {
+        if (!isEnable() || isCalledViaIdentityMgtListners() 
+                || !isEventAssociatedWithWorkflow(UserStoreWFConstants.SET_MULTIPLE_USER_CLAIMS_EVENT)) {
             return true;
         }
         try {
@@ -232,8 +233,13 @@ public class UserStoreActionListener extends AbstractIdentityUserOperationEventL
             String domain = userStoreManager.getRealmConfiguration().getUserStoreProperty(UserCoreConstants.RealmConfig
                     .PROPERTY_DOMAIN_NAME);
 
-            return setMultipleClaimsWFRequestHandler.startSetMultipleClaimsWorkflow(domain, userName, claims,
+            boolean state = setMultipleClaimsWFRequestHandler.startSetMultipleClaimsWorkflow(domain, userName, claims,
                     profileName);
+            if (!state) {
+                throw new UserStoreException("User claim update request is sent to the workflow engine for approval.",
+                        UserCoreConstants.ErrorCode.USER_CLAIMS_UPDATE_WORKFLOW_CREATED);
+            }
+            return true;
         } catch (WorkflowException e) {
             // Sending e.getMessage() since it is required to give error message to end user.
             throw new UserStoreException(e.getMessage(), e);

--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@
 
     <properties>
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.10.64</carbon.kernel.version>
+        <carbon.kernel.version>4.12.25</carbon.kernel.version>
         <carbon.kernel.feature.version>4.10.64</carbon.kernel.feature.version>
         <carbon.kernel.package.import.version.range>[4.5.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>


### PR DESCRIPTION
resolves : https://github.com/wso2/product-is/issues/27001

This pull request introduces an important behavioral change in user claim update workflows and includes a dependency update. The main update ensures that when user claim updates require workflow approval, the workflow engine is properly engaged and the correct exception is thrown to signal this state. Additionally, the Carbon kernel dependency version is updated.

**Workflow logic improvements:**

* Modified `doPreSetUserClaimValues` in `UserStoreActionListener.java` to check if the event is associated with a workflow before proceeding, ensuring workflows are only triggered when appropriate.
* Changed the method to throw a `UserStoreException` with a specific error code when a user claim update triggers a workflow approval process, improving error handling and user feedback.

**Dependency update:**

* Updated the Carbon kernel version in `pom.xml` from `4.10.64` to `4.12.25` to use a newer platform version.